### PR TITLE
fix(phase-2): Remove invalid Homebrew checksum validation

### DIFF
--- a/roles/homebrew/defaults/main.yml
+++ b/roles/homebrew/defaults/main.yml
@@ -12,4 +12,5 @@ dev_home: "{{ ansible_env.HOME }}"
 
 # Homebrew installer settings
 homebrew_installer_url: "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
-homebrew_installer_checksum: "sha256:https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh.sha256"
+# Note: Homebrew does not provide checksums for install.sh
+# Security is maintained by using HTTPS and official GitHub repository

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -10,7 +10,6 @@
     url: "{{ homebrew_installer_url }}"
     dest: /tmp/homebrew-install.sh
     mode: '0755'
-    checksum: "{{ homebrew_installer_checksum }}"
   when: not homebrew_check.stat.exists
   become: no
 


### PR DESCRIPTION
## What the PR Does

**Fixes the bug where:**
- `develop` branch has: `checksum: "{{ homebrew_installer_checksum }}"` (line 10)
- `fix/phase-2-checksum-debug` branch: Removed that line

**Changes:**
- Removed non-functional checksum parameter
- Cleaned up related variables

## Current Branch States
```
fix/phase-2-checksum-debug (c2875db) ✅ FIXED
develop (c84fc6e) ❌ HAS BUG

## Resumo por Sourcery

Remove o parâmetro de checksum não funcional do instalador do Homebrew, limpa a variável relacionada e documenta a dependência de segurança no HTTPS.

Correções de Bugs:
- Remove a validação de checksum inválida do Homebrew e a variável associada do papel

Melhorias:
- Adiciona uma nota explicando que a segurança é mantida via HTTPS e o repositório oficial do GitHub